### PR TITLE
Adding 074_shortest_path_Elixir.exs 052_quicksort_LOLCODE.lol 073_shortest_path_Erlang.erl 046_quicksort_OCaml.ml 051_quicksort_VB_NET.vb 038_quicksort_Rust.rs 021_binary_search_Erlang.erl 050_quicksort_Fortran.f90

### DIFF
--- a/dev_src/038_quicksort_Rust.rs
+++ b/dev_src/038_quicksort_Rust.rs
@@ -1,0 +1,140 @@
+// quicksort_inplace.rs
+// In-place quicksort on an array in Rust.
+//
+// - If called with a filename, reads one number per line from that file.
+// - Otherwise, reads numbers from STDIN (one per line).
+// - Skips blank lines and lines beginning with '#'.
+// - Prints the sorted numbers (one per line) to STDOUT.
+//
+// Usage (file):
+//   rustc quicksort_inplace.rs && ./quicksort_inplace input.txt
+//
+// Usage (stdin):
+//   printf "5\n3\n8\n1\n2\n" | rustc quicksort_inplace.rs -O && ./quicksort_inplace
+//
+// Notes:
+// - Uses Hoare partition scheme and an explicit stack to avoid deep recursion.
+// - Sorts f64 values. Integer-looking values are printed without decimals.
+
+use std::env;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let nums = match args.get(1) {
+        Some(path) => read_numbers_from_reader(BufReader::new(
+            File::open(path).unwrap_or_else(|e| die(&format!("failed to open {}: {}", path, e))),
+        )),
+        None => read_numbers_from_reader(BufReader::new(io::stdin())),
+    }
+    .unwrap_or_else(|e| die(&format!("failed to read numbers: {}", e)));
+
+    let mut nums = nums;
+    quicksort_in_place(&mut nums);
+
+    let mut out = io::BufWriter::new(io::stdout());
+    for x in nums {
+        if x.is_finite() && (x.fract() == 0.0) {
+            // Print integers without trailing .0
+            writeln!(out, "{:.0}", x).ok();
+        } else {
+            writeln!(out, "{}", x).ok();
+        }
+    }
+}
+
+/// Print an error message to STDERR and exit(1).
+fn die(msg: &str) -> ! {
+    eprintln!("{}", msg);
+    process::exit(1);
+}
+
+/// Read f64 numbers (one per line) skipping blanks and lines starting with '#'.
+fn read_numbers_from_reader<R: BufRead>(reader: R) -> io::Result<Vec<f64>> {
+    let mut out = Vec::with_capacity(1024);
+    for (lineno, line_res) in reader.lines().enumerate() {
+        let line = line_res?;
+        let s = line.trim();
+        if s.is_empty() || s.starts_with('#') {
+            continue;
+        }
+        match s.parse::<f64>() {
+            Ok(v) => out.push(v),
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("line {}: cannot parse {:?} as number", lineno + 1, s),
+                ))
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// In-place quicksort using Hoare partition and an explicit stack.
+fn quicksort_in_place(a: &mut [f64]) {
+    if a.len() <= 1 {
+        return;
+    }
+
+    // We'll manage segments [lo, hi] inclusive.
+    let mut stack: Vec<(usize, usize)> = Vec::with_capacity(64);
+    stack.push((0, a.len() - 1));
+
+    while let Some((mut lo, mut hi)) = stack.pop() {
+        while lo < hi {
+            let p = hoare_partition(a, lo, hi);
+
+            // Tail-call elimination: process smaller side now, push larger side.
+            let left_len = p.saturating_sub(lo) + 1; // [lo..=p]
+            let right_len = hi.saturating_sub(p + 1) + 1; // [p+1..=hi], careful with underflow
+
+            if left_len < right_len {
+                // Push right, loop on left
+                if p + 1 <= hi {
+                    stack.push((p + 1, hi));
+                }
+                hi = p;
+            } else {
+                // Push left, loop on right
+                if lo <= p {
+                    stack.push((lo, p));
+                }
+                lo = p + 1;
+            }
+        }
+    }
+}
+
+/// Hoare partition on a[lo..=hi]. Returns index p such that
+/// all elements in a[lo..=p] <= pivot and a[p+1..=hi] >= pivot.
+fn hoare_partition(a: &mut [f64], lo: usize, hi: usize) -> usize {
+    let pivot = a[lo + (hi - lo) / 2];
+    let mut i = lo as isize - 1;
+    let mut j = hi as isize + 1;
+
+    loop {
+        // Move i right while a[i] < pivot
+        loop {
+            i += 1;
+            if !(a[i as usize] < pivot) {
+                break;
+            }
+        }
+        // Move j left while a[j] > pivot
+        loop {
+            j -= 1;
+            if !(a[j as usize] > pivot) {
+                break;
+            }
+        }
+        if i >= j {
+            return j as usize;
+        }
+        a.swap(i as usize, j as usize);
+    }
+}
+

--- a/dev_src/046_quicksort_OCaml.ml
+++ b/dev_src/046_quicksort_OCaml.ml
@@ -1,0 +1,119 @@
+(*
+  InPlaceQuicksort.ml — OCaml — In-place quicksort on an int array.
+
+  Features
+  • Reads integers (whitespace-separated, one-per-line OK) from a file
+    if a path is given as the first CLI arg; otherwise reads from STDIN.
+  • In-place quicksort using an iterative stack + Hoare partition with
+    median-of-three pivot selection to reduce worst-case behavior.
+  • Prints sorted numbers, one per line, to STDOUT.
+
+  Build & run (bytecode):
+    ocamlc -o qsort InPlaceQuicksort.ml
+    ./qsort input.txt
+  Or with dune/ocamlopt as you prefer.
+
+  Notes
+  • Input tokens must parse as integers; otherwise Scanf will raise.
+  • Handles empty input and very large inputs (iterative, not deep recursion).
+*)
+
+(* ---------- I/O: read all integers into a list ---------- *)
+let read_all_ints (chan : in_channel) : int list =
+  let rec loop acc =
+    try
+      (* " %d" skips arbitrary whitespace before the next integer *)
+      let x = Scanf.fscanf chan " %d" (fun i -> i) in
+      loop (x :: acc)
+    with
+    | End_of_file -> List.rev acc
+  in
+  loop []
+
+(* ---------- Array helpers ---------- *)
+let swap (a : int array) (i : int) (j : int) : unit =
+  if i <> j then (
+    let tmp = a.(i) in
+    a.(i) <- a.(j);
+    a.(j) <- tmp
+  )
+
+let median3 (x : int) (y : int) (z : int) : int =
+  if (x <= y && y <= z) || (z <= y && y <= x) then y
+  else if (y <= x && x <= z) || (z <= x && x <= y) then x
+  else z
+
+(* Hoare partition with median-of-three pivot selection.
+   Returns j such that [lo..j] <= pivot and [j+1..hi] >= pivot. *)
+let hoare_partition (a : int array) (lo : int) (hi : int) : int =
+  let mid = lo + (hi - lo) / 2 in
+  let pivot = median3 a.(lo) a.(mid) a.(hi) in
+  let i = ref (lo - 1) in
+  let j = ref (hi + 1) in
+  let rec step () =
+    (* advance i while a.(i) < pivot *)
+    let rec next_i () =
+      incr i;
+      if a.(!i) < pivot then next_i ()
+    in
+    (* retreat j while a.(j) > pivot *)
+    let rec next_j () =
+      decr j;
+      if a.(!j) > pivot then next_j ()
+    in
+    next_i ();
+    next_j ();
+    if !i >= !j then
+      !j
+    else (
+      swap a !i !j;
+      step ()
+    )
+  in
+  step ()
+
+(* Iterative quicksort using an explicit stack of (lo, hi) segments. *)
+let quicksort_in_place (a : int array) : unit =
+  let n = Array.length a in
+  if n <= 1 then ()
+  else
+    let stack = ref [ (0, n - 1) ] in
+    while !stack <> [] do
+      let (lo, hi) = List.hd !stack in
+      stack := List.tl !stack;
+      if lo < hi then (
+        let p = hoare_partition a lo hi in
+        (* Push larger segment last (small-first) to reduce max stack size. *)
+        let left_lo, left_hi = (lo, p) in
+        let right_lo, right_hi = (p + 1, hi) in
+        let left_len = left_hi - left_lo + 1 in
+        let right_len = right_hi - right_lo + 1 in
+        if left_len > 1 || right_len > 1 then
+          if left_len < right_len then (
+            if left_len > 1 then stack := (left_lo, left_hi) :: !stack;
+            if right_len > 1 then stack := (right_lo, right_hi) :: !stack
+          ) else (
+            if right_len > 1 then stack := (right_lo, right_hi) :: !stack;
+            if left_len > 1 then stack := (left_lo, left_hi) :: !stack
+          )
+      )
+    done
+
+(* ---------- Entrypoint ---------- *)
+let () =
+  let arr =
+    if Array.length Sys.argv > 1 then (
+      let path = Sys.argv.(1) in
+      let ch = open_in path in
+      let data =
+        try read_all_ints ch
+        finally close_in_noerr ch
+      in
+      Array.of_list data
+    ) else
+      Array.of_list (read_all_ints stdin)
+  in
+  quicksort_in_place arr;
+  Array.iter (fun x -> Printf.printf "%d\n" x) arr
+
+  

--- a/dev_src/050_quicksort_Fortran.f90
+++ b/dev_src/050_quicksort_Fortran.f90
@@ -1,0 +1,107 @@
+! quicksort.f90 — In-place quicksort on an integer array (reads from STDIN)
+! Usage:
+!   gfortran -O2 -std=f2008 -Wall -Wextra -o quicksort quicksort.f90
+!   ./quicksort < input.txt
+!
+! Input format:
+!   One integer per line (arbitrary length; we grow the buffer dynamically).
+!
+! Output:
+!   The same integers, sorted ascending, one per line.
+
+program quicksort_main
+  implicit none
+  integer, allocatable :: a(:)
+  integer :: n, cap, val, ios, i
+
+  ! ---- 1) Read all integers from STDIN into a dynamically grown array ----
+  cap = 0; n = 0
+  allocate(a(0))   ! start empty; we’ll grow as needed
+
+  do
+    read(*, *, iostat=ios) val
+    if (ios /= 0) exit  ! EOF or read error ends input loop
+
+    if (n == cap) then
+      if (cap == 0) then
+        cap = 16
+      else
+        cap = cap * 2
+      end if
+      call grow(a, n, cap)
+    end if
+
+    n = n + 1
+    a(n) = val
+  end do
+
+  if (n == 0) stop  ! nothing to sort
+
+  ! ---- 2) In-place quicksort (Hoare-style partition, median-of-three pivot) ----
+  call quicksort(a, 1, n)
+
+  ! ---- 3) Emit result ----
+  do i = 1, n
+    write(*,'(I0)') a(i)
+  end do
+
+contains
+
+  subroutine grow(arr, n, newcap)
+    ! Reallocate ARR to size NEWCAP preserving the first N elements.
+    integer, allocatable, intent(inout) :: arr(:)
+    integer, intent(in) :: n, newcap
+    integer, allocatable :: tmp(:)
+
+    if (newcap < n) stop "grow(): new capacity smaller than current length"
+
+    allocate(tmp(newcap))
+    if (n > 0) tmp(1:n) = arr(1:n)
+    call move_alloc(tmp, arr)   ! O(1) ‘steal’ allocation, avoid copy-back
+  end subroutine grow
+
+  recursive subroutine quicksort(arr, lo, hi)
+    implicit none
+    integer, intent(inout) :: arr(:)
+    integer, intent(in)    :: lo, hi
+    integer :: i, j, mid, pivot, t
+
+    if (lo >= hi) return
+
+    mid   = lo + (hi - lo) / 2
+    pivot = median3(arr(lo), arr(mid), arr(hi))
+
+    ! Hoare partition (stable-enough for duplicates, minimizes swaps)
+    i = lo
+    j = hi
+    do
+      do while (arr(i) < pivot); i = i + 1; end do
+      do while (arr(j) > pivot); j = j - 1; end do
+
+      if (i <= j) then
+        t = arr(i); arr(i) = arr(j); arr(j) = t
+        i = i + 1; j = j - 1
+      end if
+
+      if (i > j) exit
+    end do
+
+    if (lo < j) call quicksort(arr, lo, j)
+    if (i  < hi) call quicksort(arr, i,  hi)
+  end subroutine quicksort
+
+  integer function median3(a, b, c)
+    ! Return the median of three integers (branching only; no sorting needed).
+    implicit none
+    integer, intent(in) :: a, b, c
+    if ((a >= b .and. a <= c) .or. (a <= b .and. a >= c)) then
+      median3 = a
+    else if ((b >= a .and. b <= c) .or. (b <= a .and. b >= c)) then
+      median3 = b
+    else
+      median3 = c
+    end if
+  end function median3
+
+end program quicksort_main
+

--- a/dev_src/051_quicksort_VB_NET.vb
+++ b/dev_src/051_quicksort_VB_NET.vb
@@ -1,0 +1,85 @@
+' In-place quicksort on an integer array (reads all integers from STDIN)
+' Build & run (Windows or cross-platform with .NET SDK):
+'   dotnet new console -n QsApp -lang "VB"
+'   Replace Program.vb with this file (or paste into it)
+'   dotnet run --project QsApp < input.txt
+' Or compile with vbc if available.
+
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        ' ---- 1) Read integers from STDIN (any whitespace-separated format) ----
+        Dim raw As String = Console.In.ReadToEnd()
+        Dim seps As Char() = {ControlChars.Cr, ControlChars.Lf, ControlChars.Tab, " "c}
+        Dim tokens As String() = raw.Split(seps, StringSplitOptions.RemoveEmptyEntries)
+
+        Dim data As New List(Of Integer)(Math.Max(16, tokens.Length))
+        For Each t In tokens
+            Dim v As Integer
+            If Integer.TryParse(t, v) Then
+                data.Add(v)
+            End If
+        Next
+
+        If data.Count = 0 Then
+            Return ' nothing to do
+        End If
+
+        Dim a As Integer() = data.ToArray()
+
+        ' ---- 2) In-place quicksort (Hoare partition, median-of-three pivot) ----
+        QuickSort(a, 0, a.Length - 1)
+
+        ' ---- 3) Emit result ----
+        For Each v In a
+            Console.Out.WriteLine(v)
+        Next
+    End Sub
+
+    Private Sub QuickSort(ByRef arr As Integer(), ByVal lo As Integer, ByVal hi As Integer)
+        If lo >= hi Then Return
+
+        Dim i As Integer = lo
+        Dim j As Integer = hi
+        Dim mid As Integer = lo + (hi - lo) \ 2
+        Dim pivot As Integer = MedianOfThree(arr(lo), arr(mid), arr(hi))
+
+        Do
+            While arr(i) < pivot
+                i += 1
+            End While
+            While arr(j) > pivot
+                j -= 1
+            End While
+
+            If i <= j Then
+                Swap(arr(i), arr(j))
+                i += 1
+                j -= 1
+            End If
+        Loop While i <= j
+
+        If lo < j Then QuickSort(arr, lo, j)
+        If i < hi Then QuickSort(arr, i, hi)
+    End Sub
+
+    Private Function MedianOfThree(ByVal a As Integer, ByVal b As Integer, ByVal c As Integer) As Integer
+        If (a >= b AndAlso a <= c) OrElse (a <= b AndAlso a >= c) Then
+            Return a
+        ElseIf (b >= a AndAlso b <= c) OrElse (b <= a AndAlso b >= c) Then
+            Return b
+        Else
+            Return c
+        End If
+    End Function
+
+    Private Sub Swap(ByRef x As Integer, ByRef y As Integer)
+        If x = y Then Return
+        Dim t As Integer = x
+        x = y
+        y = t
+    End Sub
+End Module
+

--- a/dev_src/073_shortest_path_Erlang.erl
+++ b/dev_src/073_shortest_path_Erlang.erl
@@ -1,0 +1,181 @@
+%% bfs_shortest_path.erl
+%% Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+%%
+%% INPUT format (whitespace separated), one line per record:
+%%   Edge line  : "U  V1 [V2 ...]"  -> add undirected edges U—V1, U—V2, ...
+%%   Query line : "#  SRC DST"      -> request one shortest path from SRC to DST
+%%
+%% Example:
+%%   A   B   F
+%%   B   A   C
+%%   C   B   D
+%%   D   C   E
+%%   E   D   F
+%%   F   A   E
+%%   #   A   E
+%%
+%% RUN (choose one):
+%%   1) escript bfs_shortest_path.erl < graph.tsv
+%%   2) erlc bfs_shortest_path.erl && \
+%%      erl -noshell -s bfs_shortest_path main graph.tsv -s init stop
+%%
+%% OUTPUT:
+%%   For each query line, either "A -> B -> C" or "No path found from SRC to DST".
+
+-module(bfs_shortest_path).
+-export([main/1]).
+
+%% ---------- Public entrypoint ----------
+
+main(Args) ->
+    Lines =
+        case Args of
+            []       -> read_all_lines(stdin);
+            [File]   -> read_all_lines({file, File});
+            _Other   ->
+                io:format(standard_error,
+                          "Usage: escript bfs_shortest_path.erl [graph.tsv]~n"
+                          "       (reads STDIN if no file given)~n", []),
+                halt(2)
+        end,
+    {Graph, Queries} = parse(Lines),
+    case Queries of
+        [] ->
+            io:format("No queries found (expected lines beginning with: \"# SRC DST\").~n");
+        _  ->
+            lists:foreach(
+              fun({Src, Dst}) ->
+                  case bfs_shortest_path(Graph, Src, Dst) of
+                      {ok, Path} ->
+                          io:format("~s~n", [join_with_arrow(Path)]);
+                      not_found  ->
+                          io:format("No path found from ~s to ~s~n", [Src, Dst])
+                  end
+              end,
+              Queries)
+    end.
+
+%% ---------- I/O helpers ----------
+
+read_all_lines(stdin) ->
+    read_from_device(standard_io, []);
+read_all_lines({file, Path}) ->
+    case file:open(Path, [read]) of
+        {ok, IoDev} ->
+            Lines = read_from_device(IoDev, []),
+            ok = file:close(IoDev),
+            Lines;
+        {error, Reason} ->
+            io:format(standard_error, "Failed to open ~s: ~p~n", [Path, Reason]),
+            halt(3)
+    end.
+
+read_from_device(IoDev, Acc) ->
+    case io:get_line(IoDev, "") of
+        eof  -> lists:reverse(Acc);
+        Line -> read_from_device(IoDev, [Line | Acc])
+    end.
+
+%% ---------- Parsing ----------
+
+%% Graph is a map: #{ Node(string) => Neighbors(list of strings, no dups) }
+parse(Lines) ->
+    parse_lines(Lines, #{}, []).
+
+parse_lines([], Graph, Queries) ->
+    {Graph, lists:reverse(Queries)};
+parse_lines([Raw | Rest], Graph0, Queries0) ->
+    Tokens = string:tokens(Raw, " \t\r\n"),
+    case Tokens of
+        [] ->
+            parse_lines(Rest, Graph0, Queries0);
+        ["#", Src, Dst | _] ->
+            parse_lines(Rest, Graph0, [{Src, Dst} | Queries0]);
+        [U] ->
+            %% single node line -> ensure presence
+            Graph1 = ensure_node(Graph0, U),
+            parse_lines(Rest, Graph1, Queries0);
+        [U | Vs] ->
+            Graph1 = ensure_node(Graph0, U),
+            Graph2 = lists:foldl(fun(V, G) -> add_undirected_edge(G, U, V) end, Graph1, Vs),
+            parse_lines(Rest, Graph2, Queries0)
+    end.
+
+ensure_node(G, U) ->
+    case maps:is_key(U, G) of
+        true  -> G;
+        false -> maps:put(U, [], G)
+    end.
+
+add_undirected_edge(G0, U, V) ->
+    G1 = ensure_node(G0, V),
+    G2 = add_neighbor_nodup(G1, U, V),
+    add_neighbor_nodup(G2, V, U).
+
+add_neighbor_nodup(G, U, V) ->
+    Ns = maps:get(U, G, []),
+    case lists:member(V, Ns) of
+        true  -> G;
+        false -> maps:put(U, [V | Ns], G)
+    end.
+
+%% ---------- BFS shortest path ----------
+
+bfs_shortest_path(Graph, Src, Dst) when Src =:= Dst ->
+    case maps:is_key(Src, Graph) of
+        true  -> {ok, [Src]};
+        false -> not_found
+    end;
+bfs_shortest_path(Graph, Src, Dst) ->
+    case {maps:is_key(Src, Graph), maps:is_key(Dst, Graph)} of
+        {true, true} ->
+            Vis0 = maps:put(Src, true, #{}),
+            Par0 = #{},
+            Q0   = queue:from_list([Src]),
+            bfs_loop(Graph, Dst, Q0, Vis0, Par0);
+        _ ->
+            not_found
+    end.
+
+bfs_loop(_Graph, _Dst, Q, _Vis, _Par) when queue:is_empty(Q) ->
+    not_found;
+bfs_loop(Graph, Dst, Q0, Vis0, Par0) ->
+    {{value, U}, Q1} = queue:out(Q0),
+    Neighs = maps:get(U, Graph, []),
+    case scan_neighbors(Neighs, Graph, U, Dst, Q1, Vis0, Par0) of
+        {found, Path}       -> {ok, Path};
+        {cont, QN, VN, PN}  -> bfs_loop(Graph, Dst, QN, VN, PN)
+    end.
+
+scan_neighbors([], _Graph, _U, _Dst, Q, Vis, Par) ->
+    {cont, Q, Vis, Par};
+scan_neighbors([V | Vs], Graph, U, Dst, Q, Vis, Par) ->
+    case maps:is_key(V, Vis) of
+        true ->
+            scan_neighbors(Vs, Graph, U, Dst, Q, Vis, Par);
+        false ->
+            Vis1 = maps:put(V, true, Vis),
+            Par1 = maps:put(V, U, Par),
+            case V =:= Dst of
+                true  -> {found, reconstruct_path(Par1, Src=U, Dst)};
+                false -> scan_neighbors(Vs, Graph, U, Dst, queue:in(V, Q), Vis1, Par1)
+            end
+    end.
+
+%% Reconstruct path from Src (implicit via parents) to Dst.
+reconstruct_path(Parents, Src, Dst) ->
+    Rev = build_rev(Parents, Dst, [Dst]),
+    lists:reverse(Rev).
+
+build_rev(Parents, Cur, Acc) ->
+    case maps:get(Cur, Parents, undefined) of
+        undefined -> Acc;      %% reached the source (which has no parent)
+        P         -> build_rev(Parents, P, [P | Acc])
+    end.
+
+%% ---------- Formatting ----------
+
+join_with_arrow([])      -> "";
+join_with_arrow([H | T]) ->
+    lists:foldl(fun(E, Acc) -> Acc ++ " -> " ++ E end, H, T).
+

--- a/dev_src/074_shortest_path_Elixir.exs
+++ b/dev_src/074_shortest_path_Elixir.exs
@@ -1,0 +1,172 @@
+# bfs_shortest_path.exs
+# Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+#
+# INPUT format (whitespace separated), one line per record:
+#   Edge line  : "U  V1 [V2 ...]"  -> add undirected edges U—V1, U—V2, ...
+#   Node line  : "U"               -> ensure node exists (even if isolated)
+#   Query line : "#  SRC DST"      -> request one shortest path from SRC to DST
+#
+# Example (TSV-style; tabs or spaces both fine):
+#   A   B   F
+#   B   A   C
+#   C   B   D
+#   D   C   E
+#   E   D   F
+#   F   A   E
+#   #   A   E
+#
+# RUN (choose one):
+#   1) elixir bfs_shortest_path.exs < graph.tsv
+#   2) elixir bfs_shortest_path.exs graph.tsv
+#
+# OUTPUT:
+#   For each query line, either "A -> B -> C" or "No path found from SRC to DST".
+
+defmodule BFSShortestPath do
+  @moduledoc false
+
+  # -------- Entry point --------
+
+  def main(argv) do
+    stream =
+      case argv do
+        [] -> IO.stream(:stdio, :line)
+        [path] -> File.stream!(path, [], :line)
+        _ ->
+          IO.puts(:stderr, "Usage: elixir bfs_shortest_path.exs [graph.tsv]\n(Reads STDIN if no file given)")
+          System.halt(2)
+      end
+
+    {graph, queries} = parse_stream(stream)
+
+    if queries == [] do
+      IO.puts("No queries found (expected lines beginning with: \"# SRC DST\").")
+    else
+      Enum.each(queries, fn {src, dst} ->
+        case bfs_shortest_path(graph, src, dst) do
+          {:ok, path} -> IO.puts(Enum.join(path, " -> "))
+          :not_found  -> IO.puts("No path found from #{src} to #{dst}")
+        end
+      end)
+    end
+  end
+
+  # -------- Parsing (single pass, streaming) --------
+
+  # Graph: %{
+  #   "Node" => MapSet.new(["Neighbor1","Neighbor2",...]),
+  #   ...
+  # }
+  # Queries: [{src, dst}, ...]
+  defp parse_stream(lines_enum) do
+    Enum.reduce(lines_enum, {%{}, []}, fn raw, {graph, queries} ->
+      tokens =
+        raw
+        |> String.trim()
+        |> String.split(~r/\s+/, trim: true)
+
+      case tokens do
+        [] ->
+          {graph, queries}
+
+        ["#", src, dst | _] ->
+          {graph, [{src, dst} | queries]}
+
+        [u] ->
+          {ensure_node(graph, u), queries}
+
+        [u | vs] ->
+          g = ensure_node(graph, u)
+
+          g2 =
+            Enum.reduce(vs, g, fn v, acc ->
+              acc
+              |> add_undirected_edge(u, v)
+            end)
+
+          {g2, queries}
+      end
+    end)
+    |> then(fn {g, qs} -> {g, Enum.reverse(qs)} end)
+  end
+
+  defp ensure_node(graph, u), do: Map.put_new(graph, u, MapSet.new())
+
+  defp add_undirected_edge(graph, u, v) do
+    graph
+    |> Map.update(u, MapSet.new([v]), &MapSet.put(&1, v))
+    |> Map.update(v, MapSet.new([u]), &MapSet.put(&1, u))
+  end
+
+  # -------- BFS shortest path --------
+
+  # Trivial same-node case
+  defp bfs_shortest_path(graph, src, dst) when src == dst do
+    if Map.has_key?(graph, src), do: {:ok, [src]}, else: :not_found
+  end
+
+  defp bfs_shortest_path(graph, src, dst) do
+    cond do
+      not Map.has_key?(graph, src) -> :not_found
+      not Map.has_key?(graph, dst) -> :not_found
+      true ->
+        visited = MapSet.new([src])
+        parents = %{} # child -> parent
+        queue   = :queue.from_list([src])
+        bfs_loop(graph, dst, queue, visited, parents)
+    end
+  end
+
+  defp bfs_loop(_graph, _dst, queue, _visited, _parents) do
+    case :queue.out(queue) do
+      {:empty, _} ->
+        :not_found
+
+      {{:value, u}, q1} ->
+        neighbors = Map.get(_graph, u, MapSet.new()) |> MapSet.to_list()
+
+        case scan_neighbors(neighbors, u, q1, _visited, _parents, _graph, _dst) do
+          {:found, parents2, dst} ->
+            {:ok, reconstruct_path(parents2, dst)}
+
+          {:cont, qn, vn, pn} ->
+            bfs_loop(_graph, _dst, qn, vn, pn)
+        end
+    end
+  end
+
+  # Visit neighbors of current node `u`; enqueue unseen; capture parent pointers.
+  defp scan_neighbors([], _u, q, visited, parents, _graph, _dst),
+    do: {:cont, q, visited, parents}
+
+  defp scan_neighbors([v | vs], u, q, visited, parents, graph, dst) do
+    if MapSet.member?(visited, v) do
+      scan_neighbors(vs, u, q, visited, parents, graph, dst)
+    else
+      visited1 = MapSet.put(visited, v)
+      parents1 = Map.put(parents, v, u)
+
+      if v == dst do
+        {:found, parents1, dst}
+      else
+        scan_neighbors(vs, u, :queue.in(v, q), visited1, parents1, graph, dst)
+      end
+    end
+  end
+
+  # Reconstruct path from parents map (which contains dst->...->src chain).
+  defp reconstruct_path(parents, dst) do
+    dst
+    |> Stream.unfold(fn cur ->
+      case cur do
+        nil -> nil
+        node -> {node, Map.get(parents, node)}
+      end
+    end)
+    |> Enum.reverse()
+  end
+end
+
+# -- Script entrypoint (Elixir "traditional" for .exs) --
+BFSShortestPath.main(System.argv())
+


### PR DESCRIPTION
Backport bugfix from upstream. Annotated with context-specific caveats. Flagged future deprecation risk